### PR TITLE
Custom keyboard blocks

### DIFF
--- a/ardublock/src/main/java/com/ardublock/translator/block/KeyboardKeyBlock.java
+++ b/ardublock/src/main/java/com/ardublock/translator/block/KeyboardKeyBlock.java
@@ -1,0 +1,22 @@
+package com.ardublock.translator.block;
+
+import com.ardublock.translator.Translator;
+import com.ardublock.translator.block.exception.SocketNullException;
+import com.ardublock.translator.block.exception.SubroutineNotDeclaredException;
+
+public class KeyboardKeyBlock extends TranslatorBlock
+{
+	public KeyboardKeyBlock(Long blockId, Translator translator, String codePrefix, String codeSuffix, String label)
+	{
+		super(blockId, translator, codePrefix, codeSuffix, label);
+	}
+
+	@Override
+	public String toCode() throws SocketNullException
+	{
+		/**
+		 * DO NOT add tab in code any more, we'll use arduino to format code, or the code will duplicated. 
+		 */
+		return codePrefix + "'" + label + "'" + codeSuffix;
+	}
+}

--- a/ardublock/src/main/java/com/ardublock/translator/block/KeyboardPressBlock.java
+++ b/ardublock/src/main/java/com/ardublock/translator/block/KeyboardPressBlock.java
@@ -1,0 +1,27 @@
+package com.ardublock.translator.block;
+
+import com.ardublock.translator.Translator;
+import com.ardublock.translator.block.exception.SocketNullException;
+import com.ardublock.translator.block.exception.SubroutineNotDeclaredException;
+
+public class KeyboardPressBlock extends TranslatorBlock
+{
+	public KeyboardPressBlock(Long blockId, Translator translator, String codePrefix, String codeSuffix, String label)
+	{
+		super(blockId, translator, codePrefix, codeSuffix, label);
+	}
+
+	@Override
+	public String toCode() throws SocketNullException, SubroutineNotDeclaredException
+	{
+		/**
+		 * DO NOT add tab in code any more, we'll use arduino to format code, or the code will duplicated. 
+		 */
+		translator.addHeaderFile("Keyboard.h");
+		translator.addSetupCommand("Keyboard.begin();");
+
+		TranslatorBlock translatorBlock = this.getRequiredTranslatorBlockAtSocket(0, "Keyboard.press(", ");");
+
+		return translatorBlock.toCode();
+	}
+}

--- a/ardublock/src/main/java/com/ardublock/translator/block/KeyboardPrintBlock.java
+++ b/ardublock/src/main/java/com/ardublock/translator/block/KeyboardPrintBlock.java
@@ -1,0 +1,27 @@
+package com.ardublock.translator.block;
+
+import com.ardublock.translator.Translator;
+import com.ardublock.translator.block.exception.SocketNullException;
+import com.ardublock.translator.block.exception.SubroutineNotDeclaredException;
+
+public class KeyboardPrintBlock extends TranslatorBlock
+{
+	public KeyboardPrintBlock(Long blockId, Translator translator, String codePrefix, String codeSuffix, String label)
+	{
+		super(blockId, translator, codePrefix, codeSuffix, label);
+	}
+
+	@Override
+	public String toCode() throws SocketNullException, SubroutineNotDeclaredException
+	{
+		/**
+		 * DO NOT add tab in code any more, we'll use arduino to format code, or the code will duplicated. 
+		 */
+		translator.addHeaderFile("Keyboard.h");
+		translator.addSetupCommand("Keyboard.begin();");
+
+		TranslatorBlock translatorBlock = this.getRequiredTranslatorBlockAtSocket(0, "Keyboard.print(", ");");
+
+		return translatorBlock.toCode();
+	}
+}

--- a/ardublock/src/main/java/com/ardublock/translator/block/KeyboardReleaseAllBlock.java
+++ b/ardublock/src/main/java/com/ardublock/translator/block/KeyboardReleaseAllBlock.java
@@ -1,0 +1,27 @@
+package com.ardublock.translator.block;
+
+import com.ardublock.translator.Translator;
+import com.ardublock.translator.block.exception.SocketNullException;
+import com.ardublock.translator.block.exception.SubroutineNotDeclaredException;
+
+public class KeyboardReleaseAllBlock extends TranslatorBlock
+{
+	public KeyboardReleaseAllBlock(Long blockId, Translator translator, String codePrefix, String codeSuffix, String label)
+	{
+		super(blockId, translator, codePrefix, codeSuffix, label);
+	}
+
+	@Override
+	public String toCode() throws SocketNullException, SubroutineNotDeclaredException
+	{
+		/**
+		 * DO NOT add tab in code any more, we'll use arduino to format code, or the code will duplicated. 
+		 */
+		translator.addHeaderFile("Keyboard.h");
+		translator.addSetupCommand("Keyboard.begin();");
+
+		TranslatorBlock translatorBlock = this.getRequiredTranslatorBlockAtSocket(0, "Keyboard.print(", ");");
+
+		return "Keyboard.releaseAll();";
+	}
+}

--- a/ardublock/src/main/java/com/ardublock/translator/block/KeyboardReleaseBlock.java
+++ b/ardublock/src/main/java/com/ardublock/translator/block/KeyboardReleaseBlock.java
@@ -1,0 +1,27 @@
+package com.ardublock.translator.block;
+
+import com.ardublock.translator.Translator;
+import com.ardublock.translator.block.exception.SocketNullException;
+import com.ardublock.translator.block.exception.SubroutineNotDeclaredException;
+
+public class KeyboardReleaseBlock extends TranslatorBlock
+{
+	public KeyboardReleaseBlock(Long blockId, Translator translator, String codePrefix, String codeSuffix, String label)
+	{
+		super(blockId, translator, codePrefix, codeSuffix, label);
+	}
+
+	@Override
+	public String toCode() throws SocketNullException, SubroutineNotDeclaredException
+	{
+		/**
+		 * DO NOT add tab in code any more, we'll use arduino to format code, or the code will duplicated. 
+		 */
+		translator.addHeaderFile("Keyboard.h");
+		translator.addSetupCommand("Keyboard.begin();");
+
+		TranslatorBlock translatorBlock = this.getRequiredTranslatorBlockAtSocket(0, "Keyboard.release(", ");");
+
+		return translatorBlock.toCode();
+	}
+}

--- a/ardublock/src/main/resources/com/ardublock/block/ardublock.properties
+++ b/ardublock/src/main/resources/com/ardublock/block/ardublock.properties
@@ -372,6 +372,13 @@ bg.true=TRUE
 bg.string_equal=equals
 bg.string_empty=is empty
 
+bg.keyboard_print=keyboard print
+bg.keyboard_press=keyboard press
+bg.keyboard_release=keyboard release
+bg.keyboard_release_all=keyboard release all
+bc.key=key
+bg.key=key
+
 bg.ultrasonic=ultrasonic
 bg.LCD_I2C_Sainsmart_20by4=20by4 I2C  Sainsmart
 bg.LCD_I2C_Sainsmart_16by2=16by2 I2C  Sainsmart
@@ -535,6 +542,7 @@ bg.code_setup=setup
 bd.logic=Tests
 bd.communication=Communication
 bd.especial=Code Blocks
+bd.keyboard=Keyboard
 
 bd.adafruit=Adafruit
 bg.ada_dc_motor_fwd=DC motor FORWARD

--- a/ardublock/src/main/resources/com/ardublock/block/ardublock.xml
+++ b/ardublock/src/main/resources/com/ardublock/block/ardublock.xml
@@ -2242,6 +2242,8 @@
 				<BlockConnector connector-type="poly" connector-kind="plug" position-type="mirror" />
 			</BlockConnectors>
 		</BlockGenus>
+
+
 		
 	    <BlockGenus name="setter_variable_String" kind="command" color="245 245 245" initlabel="bg.setter_variable_String">
 	      <description>
@@ -2567,6 +2569,7 @@
 			</BlockConnectors>
 		</BlockGenus>
 
+
 		<BlockGenus name="message" kind="data" color="245 245 245" initlabel="bg.message" editable-label="yes">
 			<description>
 				<text>string message</text>
@@ -2604,6 +2607,59 @@
 			<BlockConnectors>
 				<BlockConnector connector-type="string" connector-kind="plug" />
 				<BlockConnector connector-type="poly" connector-kind="socket" />
+			</BlockConnectors>
+		</BlockGenus>
+
+		<!-- keyboard stuff -->
+		<BlockGenus name="keyboard_print" kind="command" color="245 245 245" initlabel="bg.keyboard_print">
+			<description>
+				<text>send message via keyboard</text>
+			</description>
+			<BlockConnectors>
+				<BlockConnector connector-type="string" connector-kind="socket" label="bc.message">
+					<DefaultArg genus-name="message" label="message" />
+				</BlockConnector>
+			</BlockConnectors>
+		</BlockGenus>
+
+		<BlockGenus name="keyboard_press" kind="command" color="245 245 245" initlabel="bg.keyboard_press">
+			<description>
+				<text>press down a keyboard key</text>
+			</description>
+			<BlockConnectors>
+				<BlockConnector connector-type="poly" connector-kind="socket" label="==">
+					<DefaultArg genus-name="key" label="A" />
+				</BlockConnector>
+			</BlockConnectors>
+		</BlockGenus>
+
+		<BlockGenus name="keyboard_release" kind="command" color="245 245 245" initlabel="bg.keyboard_release">
+			<description>
+				<text>release (unpress) a keyboard key</text>
+			</description>
+			<BlockConnectors>
+				<BlockConnector connector-type="poly" connector-kind="socket" label="==">
+					<DefaultArg genus-name="key" label="A" />
+				</BlockConnector>
+			</BlockConnectors>
+		</BlockGenus>
+
+		<BlockGenus name="keyboard_release_all" kind="command" color="245 245 245" initlabel="bg.keyboard_release_all">
+			<description>
+				<text>release (unpress) all keyboard keys</text>
+			</description>
+			<BlockConnectors>
+			</BlockConnectors>
+		</BlockGenus>
+
+		<BlockGenus name="key" kind="data" color="102 255 51" initlabel="bg.key" editable-label="yes">
+			<description>
+				<text>
+					key
+				</text>
+			</description>
+			<BlockConnectors>
+				<BlockConnector connector-type="poly" connector-kind="plug" position-type="mirror" />
 			</BlockConnectors>
 		</BlockGenus>
 
@@ -11848,6 +11904,11 @@
 				<BlockGenusMember>serial_available2</BlockGenusMember>
 				<BlockGenusMember>serial_read</BlockGenusMember>
 				<BlockGenusMember>serial_parseInt</BlockGenusMember>
+				<BlockGenusMember>keyboard_print</BlockGenusMember>
+				<BlockGenusMember>keyboard_press</BlockGenusMember>
+				<BlockGenusMember>keyboard_release</BlockGenusMember>
+				<BlockGenusMember>keyboard_release_all</BlockGenusMember>
+				<BlockGenusMember>key</BlockGenusMember>
 				<!-- <BlockGenusMember>DuinoEDU_Guino_Read</BlockGenusMember>
 				<BlockGenusMember>DuinoEDU_Guino_Slider</BlockGenusMember>
 				<BlockGenusMember>DuinoEDU_Guino_switch</BlockGenusMember>
@@ -11862,6 +11923,13 @@
 				<BlockGenusMember>Serialplus_receive_number</BlockGenusMember>
 				<BlockGenusMember>Serialplus_receive_digital</BlockGenusMember> -->
 			</BlockDrawer>
+			<!--<BlockDrawer button-color="127 255 127" name="bd.keyboard" type="factory">
+
+				<BlockGenusMember>keyboard_print</BlockGenusMember>
+				<BlockGenusMember>keyboard_press</BlockGenusMember>
+				<BlockGenusMember>keyboard_release</BlockGenusMember>
+				<BlockGenusMember>keyboard_release_all</BlockGenusMember>
+			</BlockDrawer>-->
 			<!-- <BlockDrawer button-color="26 97 218" name="bd.scoop">
 			    <BlockGenusMember>scoop_task</BlockGenusMember>
 				<BlockGenusMember>scoop_loop</BlockGenusMember>

--- a/ardublock/src/main/resources/com/ardublock/block/block-mapping.properties
+++ b/ardublock/src/main/resources/com/ardublock/block/block-mapping.properties
@@ -318,6 +318,13 @@ ir_getcode=com.ardublock.translator.block.IrGetCodeBlock
 bluno_println=com.ardublock.translator.block.BlunoOledPrintlnBlock
 bluno_println_number=com.ardublock.translator.block.BlunoOledPrintlnNumberBlock
 bluno_println_clear=com.ardublock.translator.block.BlunoOledClearBlock
+
+#Keyboard
+keyboard_print=com.ardublock.translator.block.KeyboardPrintBlock
+keyboard_press=com.ardublock.translator.block.KeyboardPressBlock
+keyboard_release=com.ardublock.translator.block.KeyboardReleaseBlock
+keyboard_release_all=com.ardublock.translator.block.KeyboardReleaseAllBlock
+key=com.ardublock.translator.block.KeyboardKeyBlock
 #Storage
 eeprom_read=com.ardublock.translator.block.storage.EEPROMReadBlock
 eeprom_write=com.ardublock.translator.block.storage.EEPROMWriteBlock


### PR DESCRIPTION
This adds keyboard support. Tested and confirmed working using an Arduino Leonardo. No additional libraries required.

Added under communication:
* Keyboard.print
* Keyboard.press
* Keyboard.release
* Keyboard.releaseAll
* key (represents a char, as the existing char types used double quotes and broke functions). key is used for press and release. 

Some improvements could be made.
* Removing the ability to put any other type into press/release
* Converting to a dropdown
* Adding special keys (up, down, left, right, modifiers, f1-12, etc)
* Limiting the number of characters able to be entered